### PR TITLE
Adding install setting to debian folder support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Run `parse_git_log` inside a Git repository folder to print out a
 Debian-compatible changelog without creating a Debian folder or writing
 any files.
 
+The `install` option in `deb.json` allows additional files to be installed
+in specified folders. (It is a simple wrapper around debian/install and
+the dh_install behavior.)
+
+```json
+{
+    "project": "projectname",
+    ...
+    "install": {
+        "static/images/*.jpg": "/opt/projectname/static/images/",
+        "static/css/main.css": "/opt/projectname/static/css/main.css"
+    }
+}
+```
+
 ## Customizing
 
 There are a lot of customizable options in the deb.json file or by using the

--- a/debfolder/defaults.py
+++ b/debfolder/defaults.py
@@ -1,6 +1,8 @@
 DEBIAN_FILES = {
     "compat": """{version}
 """,
+    "install": """{install}
+""",
     "control": """Source: {project}
 Section: {section}
 Priority: {priority}
@@ -44,6 +46,9 @@ DEFAULT_OPTIONS = {
         "extra_build_options": """overide_dh_virtualenv:
 \tdh_virtualenv --python /usr/bin/python2.7 --setuptools
     """
+    },
+    "install": {
+        "install": ""
     }
 }
 
@@ -56,12 +61,14 @@ REQUIRED_SETTINGS = {
 OPTIONAL_SETTINGS = {
     "depends": "control",
     "build_depends": "control",
-    "architecture": "control"
+    "architecture": "control",
+    "install": "install"
 }
 
 MERGE_COMMANDS = {
     "depends": lambda x, y: x + y,
     "build_depends": lambda x, y: x + y,
+    "install": lambda x, y: "\n".join([" ".join(i) for i in y.items()] + [x])
 }
 
 DEFAULT_MERGE = lambda x, y: y

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -37,6 +37,16 @@ BASIC_SETTINGS = {
     "description": "Description"
 }
 
+INSTALL_SETTINGS = {
+    "project": "project",
+    "maintainer": "Joe <joe@email.com>",
+    "description": "Description",
+    "install": {
+        "foo/bar/*": "/dest/dir/bar/",
+        "foo/*": "/dest/dir/"
+    }
+}
+
 
 class TestSetupHelpers(unittest.TestCase):
 
@@ -67,6 +77,18 @@ class TestSetupHelpers(unittest.TestCase):
 
     # TODO: check optional and required attributes
     # TODO: check merge and coerce behavior
+
+    def test_initialize_debian_folder_with_install(self):
+        setup_helpers.initialize_debian_folder(INSTALL_SETTINGS, self.tempdir)
+        full_path = os.path.join(self.tempdir, "debian", "install")
+        self.assertTrue(os.path.exists(full_path))
+        with open(full_path) as install_fp:
+            contents = dict([
+                a.strip().split(" ") for a in install_fp.readlines()
+                if a.strip()
+            ])
+
+        self.assertEqual(contents, INSTALL_SETTINGS["install"])
 
     @mock.patch("debfolder.git_helpers.generate_changelog_entry")
     @mock.patch("debfolder.git_helpers.parse_commits")


### PR DESCRIPTION
Adding the ability to specify additional installation files. Useful for static files, extra scripts, etc. Simply wraps the `debian/install` file.

@ckrough For your consideration, I suppose.
